### PR TITLE
Feat guards

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,19 @@ import { UserModule } from './user/user.module';
 import { PrismaService } from './prisma/prisma.service';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), UserModule, AuthModule],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+      signOptions: { expiresIn: process.env.JWT_EXP },
+      global: true,
+    }),
+    UserModule,
+    AuthModule,
+  ],
   controllers: [AppController],
   providers: [AppService, PrismaService],
 })

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,16 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
-import { JwtModule } from '@nestjs/jwt';
 import { PrismaService } from '../prisma/prisma.service';
+import { JwtModule } from '@nestjs/jwt';
 
 @Module({
-  imports: [
-    JwtModule.register({
-      secret: process.env.JWT_SECRET,
-      signOptions: { expiresIn: process.env.JWT_EXP },
-    }),
-  ],
+  imports: [JwtModule],
   controllers: [AuthController],
   providers: [AuthService, PrismaService],
 })

--- a/src/common/guards/authorization.guard.ts
+++ b/src/common/guards/authorization.guard.ts
@@ -1,0 +1,29 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class AuthorizationGuard implements CanActivate {
+  constructor(private readonly jwt: JwtService) {}
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request: Request = context.switchToHttp().getRequest();
+
+    const authorizationHeader: string = request.headers.authorization;
+    if (!authorizationHeader)
+      throw new UnauthorizedException('Sem autorização na requisição');
+
+    const token: string = authorizationHeader.split('Bearer ')[1];
+    const decoded = this.jwt.verify(token);
+
+    return !!decoded;
+  }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuthorizationGuard } from '../common/guards/authorization.guard';
+import { JwtModule } from '@nestjs/jwt';
 
 @Module({
+  imports: [JwtModule],
   controllers: [UserController],
-  providers: [UserService, PrismaService],
+  providers: [UserService, PrismaService, AuthorizationGuard],
 })
 export class UserModule {}


### PR DESCRIPTION
Guarda de rota para autorização criada.

A guarda AuthrorizationGuard controla acesso de usuários pelo token JWT enviado na header da request.
Se não houver um token, não será autorizado o acesso a rota.
O uso ainda não foi implementado no sistema. Será principalmente usado nas rotas dos lembretes , acesso e alteração de dados pessoais do usuário.