### PR TITLE
Feat db model

### DIFF
--- a/http/readme.md
+++ b/http/readme.md
@@ -1,0 +1,1 @@
+Pasta destinada aos arquivos com extensão .http para testar rotas

--- a/http/reminder-requests.http
+++ b/http/reminder-requests.http
@@ -1,0 +1,12 @@
+### Create reminder
+
+POST http://localhost:3000/reminder HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNzA1OTcyMjQzLCJleHAiOjE3MDU5NzU4NDN9.z9dfcAoHII6lhoI88d7KBdnHshjuytnm5EhPpv51-vk
+
+{
+  "title" : "Lembrar de codar",
+  "description" : "Lembrete para codar TypeScript pela manhã",
+  "platform" : "Whatsapp",
+  "scheduled" : "2024-02-23T01:06:18.179Z"
+}

--- a/http/user-requests.http
+++ b/http/user-requests.http
@@ -1,7 +1,7 @@
 ### create one user account
 
 POST http://localhost:3000/user HTTP/1.1
-Content-type: application/json
+Content-Type: application/json
 
 {
   "email" : "test@email.com",

--- a/prisma/migrations/20240116224337_reminders_and_users_to_reminder/migration.sql
+++ b/prisma/migrations/20240116224337_reminders_and_users_to_reminder/migration.sql
@@ -1,0 +1,56 @@
+/*
+  Warnings:
+
+  - You are about to drop the `User` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "User";
+
+-- CreateTable
+CREATE TABLE "Users" (
+    "id" SERIAL NOT NULL,
+    "email" VARCHAR(128) NOT NULL,
+    "password" VARCHAR(128) NOT NULL,
+    "phone" VARCHAR(64) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Reminders" (
+    "id" SERIAL NOT NULL,
+    "ownerId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Reminders_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UsersToReminder" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "reminderId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UsersToReminder_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Users_email_key" ON "Users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Users_phone_key" ON "Users"("phone");
+
+-- AddForeignKey
+ALTER TABLE "Reminders" ADD CONSTRAINT "Reminders_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "Users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UsersToReminder" ADD CONSTRAINT "UsersToReminder_userId_fkey" FOREIGN KEY ("userId") REFERENCES "Users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UsersToReminder" ADD CONSTRAINT "UsersToReminder_reminderId_fkey" FOREIGN KEY ("reminderId") REFERENCES "Reminders"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20240123010926_reminders_updated/migration.sql
+++ b/prisma/migrations/20240123010926_reminders_updated/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - Added the required column `description` to the `Reminders` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `platform` to the `Reminders` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `scheduled` to the `Reminders` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `title` to the `Reminders` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Reminders" ADD COLUMN     "description" TEXT NOT NULL,
+ADD COLUMN     "isActivated" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "platform" VARCHAR(12) NOT NULL,
+ADD COLUMN     "scheduled" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "title" VARCHAR(128) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,13 +27,12 @@ model Reminders {
   description     String
   platform        String            @db.VarChar(12)
   scheduled       DateTime
-  activate        Boolean           @default(true)
+  isActivated     Boolean           @default(true)
   owner           Users             @relation(fields: [ownerId], references: [id])
   ownerId         Int
   usersToReminder UsersToReminder[]
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
 }
 
 model UsersToReminder {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,17 +10,32 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model User {
-  id        Int      @id @default(autoincrement())
-  email     String   @unique @db.VarChar(128)
-  password  String   @db.VarChar(128)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  // Reminder  Reminder[]
+model Users {
+  id              Int               @id @default(autoincrement())
+  email           String            @unique @db.VarChar(128)
+  password        String            @db.VarChar(128)
+  phone           String            @unique @db.VarChar(64)
+  reminder        Reminders[]
+  usersToReminder UsersToReminder[]
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
 }
 
-// model Reminder {
-//   id     Int  @id @default(autoincrement())
-//   owner  User @relation(fields: [userId], references: [id])
-//   userId Int
-// }
+model Reminders {
+  id              Int               @id @default(autoincrement())
+  owner           Users             @relation(fields: [ownerId], references: [id])
+  ownerId         Int
+  usersToReminder UsersToReminder[]
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
+}
+
+model UsersToReminder {
+  id         Int       @id @default(autoincrement())
+  user       Users     @relation(fields: [userId], references: [id])
+  userId     Int
+  reminder   Reminders @relation(fields: [reminderId], references: [id])
+  reminderId Int
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,7 +24,7 @@ model Users {
 model Reminders {
   id              Int               @id @default(autoincrement())
   title           String            @db.VarChar(128)
-  description     String            @db.Text
+  description     String
   platform        String            @db.VarChar(12)
   scheduled       DateTime
   activate        Boolean           @default(true)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,11 +23,17 @@ model Users {
 
 model Reminders {
   id              Int               @id @default(autoincrement())
+  title           String            @db.VarChar(128)
+  description     String            @db.Text
+  platform        String            @db.VarChar(12)
+  scheduled       DateTime
+  activate        Boolean           @default(true)
   owner           Users             @relation(fields: [ownerId], references: [id])
   ownerId         Int
   usersToReminder UsersToReminder[]
-  createdAt       DateTime          @default(now())
-  updatedAt       DateTime          @updatedAt
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model UsersToReminder {

--- a/requests.http
+++ b/requests.http
@@ -5,6 +5,7 @@ Content-type: application/json
 
 {
   "email" : "test@email.com",
+  "phone" : "19987851001",
   "password" : "senhaForte"
 }
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,10 @@ import { UserModule } from './user/user.module';
 import { PrismaService } from './prisma/prisma.service';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
+import { ReminderModule } from './reminder/reminder.module';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), UserModule, AuthModule],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), UserModule, AuthModule, ReminderModule],
   controllers: [AppController],
   providers: [AppService, PrismaService],
 })

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { CredentialsDto } from './dto/credentials.dto';
 import { PrismaService } from '../prisma/prisma.service';
 import { HashUtil } from '../common/utils/hashUtil';
-import { User } from '@prisma/client';
+import { Users } from '@prisma/client';
 import { JwtService } from '@nestjs/jwt';
 import { JwtPayload } from './interfaces/jwt-payload.interface';
 
@@ -14,7 +14,7 @@ export class AuthService {
   ) {}
 
   async login(credentials: CredentialsDto): Promise<{ token: string }> {
-    const foundUser: User = await this.prisma.user.findFirst({
+    const foundUser: Users = await this.prisma.users.findFirst({
       where: {
         email: credentials.email,
       },

--- a/src/common/guards/authorization.guard.ts
+++ b/src/common/guards/authorization.guard.ts
@@ -23,7 +23,9 @@ export class AuthorizationGuard implements CanActivate {
 
     const token: string = authorizationHeader.split('Bearer ')[1];
     const decoded = this.jwt.verify(token);
-
-    return !!decoded;
+    if (decoded) {
+      request['user'] = decoded;
+      return !!decoded;
+    }
   }
 }

--- a/src/reminder/dto/create-reminder.dto.ts
+++ b/src/reminder/dto/create-reminder.dto.ts
@@ -26,6 +26,5 @@ export class CreateReminderDto {
   scheduled: Date;
   @IsNotEmpty()
   @IsInt()
-  @ApiProperty()
   ownerId: number;
 }

--- a/src/reminder/dto/create-reminder.dto.ts
+++ b/src/reminder/dto/create-reminder.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsInt, IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateReminderDto {
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty()
+  title: string;
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty()
+  description: string;
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty()
+  platform: string;
+  @IsNotEmpty()
+  @IsDate()
+  @ApiProperty()
+  scheduled: Date;
+  @IsNotEmpty()
+  @IsInt()
+  @ApiProperty()
+  ownerId: number;
+}

--- a/src/reminder/dto/create-reminder.dto.ts
+++ b/src/reminder/dto/create-reminder.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDate, IsInt, IsNotEmpty, IsString } from 'class-validator';
+import {
+  IsDate,
+  IsDateString,
+  IsInt,
+  IsNotEmpty,
+  IsString,
+} from 'class-validator';
 
 export class CreateReminderDto {
   @IsNotEmpty()
@@ -15,7 +21,7 @@ export class CreateReminderDto {
   @ApiProperty()
   platform: string;
   @IsNotEmpty()
-  @IsDate()
+  @IsDateString()
   @ApiProperty()
   scheduled: Date;
   @IsNotEmpty()

--- a/src/reminder/dto/update-reminder.dto.ts
+++ b/src/reminder/dto/update-reminder.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateReminderDto } from './create-reminder.dto';
+
+export class UpdateReminderDto extends PartialType(CreateReminderDto) {}

--- a/src/reminder/guards/add-owner-to-body.guard.ts
+++ b/src/reminder/guards/add-owner-to-body.guard.ts
@@ -1,0 +1,16 @@
+import { CanActivate, ExecutionContext } from '@nestjs/common';
+import { Request } from 'express';
+import { Observable } from 'rxjs';
+
+export class AddOwnerToBodyGuard implements CanActivate {
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request: Request = context.switchToHttp().getRequest();
+    if (request['user']) {
+      request.body['ownerId'] = request['user'].id;
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/reminder/guards/index.ts
+++ b/src/reminder/guards/index.ts
@@ -1,0 +1,1 @@
+export * from './add-owner-to-body.guard';

--- a/src/reminder/reminder.controller.spec.ts
+++ b/src/reminder/reminder.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReminderController } from './reminder.controller';
+import { ReminderService } from './reminder.service';
+
+describe('ReminderController', () => {
+  let controller: ReminderController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReminderController],
+      providers: [ReminderService],
+    }).compile();
+
+    controller = module.get<ReminderController>(ReminderController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/reminder/reminder.controller.ts
+++ b/src/reminder/reminder.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ReminderService } from './reminder.service';
+import { CreateReminderDto } from './dto/create-reminder.dto';
+
+@Controller('reminder')
+export class ReminderController {
+  constructor(private readonly reminderService: ReminderService) {}
+
+  @Post('')
+  createReminder(@Body() createReminderDto: CreateReminderDto) {
+    return this.reminderService.createReminder(createReminderDto);
+  }
+}

--- a/src/reminder/reminder.controller.ts
+++ b/src/reminder/reminder.controller.ts
@@ -1,11 +1,13 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { ReminderService } from './reminder.service';
 import { CreateReminderDto } from './dto/create-reminder.dto';
+import { AuthorizationGuard } from '../common/guards/authorization.guard';
+import { AddOwnerToBodyGuard } from './guards';
 
 @Controller('reminder')
 export class ReminderController {
   constructor(private readonly reminderService: ReminderService) {}
-
+  @UseGuards(AuthorizationGuard, AddOwnerToBodyGuard)
   @Post('')
   createReminder(@Body() createReminderDto: CreateReminderDto) {
     return this.reminderService.createReminder(createReminderDto);

--- a/src/reminder/reminder.module.ts
+++ b/src/reminder/reminder.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ReminderService } from './reminder.service';
+import { ReminderController } from './reminder.controller';
+
+@Module({
+  controllers: [ReminderController],
+  providers: [ReminderService],
+})
+export class ReminderModule {}

--- a/src/reminder/reminder.module.ts
+++ b/src/reminder/reminder.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ReminderService } from './reminder.service';
 import { ReminderController } from './reminder.controller';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Module({
   controllers: [ReminderController],
-  providers: [ReminderService],
+  providers: [ReminderService, PrismaService],
 })
 export class ReminderModule {}

--- a/src/reminder/reminder.service.spec.ts
+++ b/src/reminder/reminder.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReminderService } from './reminder.service';
+
+describe('ReminderService', () => {
+  let service: ReminderService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ReminderService],
+    }).compile();
+
+    service = module.get<ReminderService>(ReminderService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/reminder/reminder.service.ts
+++ b/src/reminder/reminder.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateReminderDto } from './dto/create-reminder.dto';
+
+@Injectable()
+export class ReminderService {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async createReminder(reminderDto: CreateReminderDto) {
+    return await this.prismaService.reminders.create({
+      data: reminderDto,
+    });
+  }
+}

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
   IsEmail,
+  IsMobilePhone,
   IsNotEmpty,
   IsString,
   IsStrongPassword,
@@ -13,7 +14,6 @@ const passwordDecoratorOptions: IsStrongPasswordOptions = {
   minSymbols: 0,
   minUppercase: 1,
 };
-
 export class CreateUserDto {
   @IsNotEmpty()
   @IsString()
@@ -25,4 +25,9 @@ export class CreateUserDto {
   @IsEmail()
   @ApiProperty()
   email: string;
+  @IsNotEmpty()
+  @IsString()
+  @IsMobilePhone('pt-BR')
+  @ApiProperty()
+  phone: string;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -12,7 +12,7 @@ import {
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { User } from '@prisma/client';
+import { Users } from '@prisma/client';
 
 @Controller('user')
 export class UserController {
@@ -25,7 +25,7 @@ export class UserController {
 
   @Get(':id')
   async findOne(@Param('id', ParseIntPipe) id: string) {
-    const user: Partial<User> | null = await this.userService.findOne(+id);
+    const user: Partial<Users> | null = await this.userService.findOne(+id);
     if (!user)
       throw new NotFoundException(`Usuário com id ${id} não foi encontrado.`);
     return user;

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -3,7 +3,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { HashUtil } from '../common/utils/hashUtil';
-import { User } from '@prisma/client';
+import { Users } from '@prisma/client';
 
 @Injectable()
 export class UserService {
@@ -15,21 +15,21 @@ export class UserService {
     const hashedPassword = await HashUtil.hash(createUserDto.password);
     createUserDto.password = hashedPassword;
 
-    await this.prismaService.user.create({
+    await this.prismaService.users.create({
       data: createUserDto,
     });
   }
 
-  async findOne(id: number): Promise<Partial<User> | null> {
-    const foundUser: User | null = await this.prismaService.user.findFirst({
+  async findOne(id: number): Promise<Partial<Users> | null> {
+    const foundUser: Users | null = await this.prismaService.users.findFirst({
       where: { id },
     });
     const { password, ...secureUserData } = foundUser;
     return secureUserData;
   }
 
-  update(id: number, updateUserDto: UpdateUserDto) {
-    const user = this.prismaService.user.update({
+  async update(id: number, updateUserDto: UpdateUserDto): Promise<void> {
+    const user = await this.prismaService.users.update({
       where: {
         id,
       },
@@ -39,7 +39,7 @@ export class UserService {
 
   async remove(id: number): Promise<void> {
     try {
-      await this.prismaService.user.delete({
+      await this.prismaService.users.delete({
         where: {
           id,
         },


### PR DESCRIPTION
Modificações no schema.prisma foram realizadas, dentre elas: criação dos reminders, atualização da tabela user e renomeação para users, criação da tabela user-to-reminders. 
API de reminders foi criada e uma rota POST para criação de reminder foi criada. Sendo que primeiramente o usuário envia os dados necessários para criar o reminder assim como consta no Swagger. Assim que é enviado, uma guarda de rota decodifica o token JWT, pega o id do usuário e insere no body da requisição como uma propriedade chamada ownerId. Essa propriedade é o que vai vincular o usuário ao lembrete.