### PR TITLE
Fix tests

### DIFF
--- a/src/category/category.service.spec.ts
+++ b/src/category/category.service.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CategoryService } from './category.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 describe('CategoryService', () => {
   let service: CategoryService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CategoryService],
+      providers: [
+        CategoryService,
+        {
+          provide: PrismaService,
+          useValue: {
+            // Defina os métodos mock do PrismaService que o ReminderService usa
+          },
+        },
+      ],
     }).compile();
 
     service = module.get(CategoryService);

--- a/src/category/category.service.spec.ts
+++ b/src/category/category.service.spec.ts
@@ -9,7 +9,7 @@ describe('CategoryService', () => {
       providers: [CategoryService],
     }).compile();
 
-    service = module.get<CategoryService>(CategoryService);
+    service = module.get(CategoryService);
   });
 
   it('should be defined', () => {

--- a/src/reminder/reminder.service.spec.ts
+++ b/src/reminder/reminder.service.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ReminderService } from './reminder.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 describe('ReminderService', () => {
   let service: ReminderService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ReminderService],
+      providers: [
+        ReminderService,
+        {
+          provide: PrismaService,
+          useValue: {
+            // Defina os métodos mock do PrismaService que o ReminderService usa
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<ReminderService>(ReminderService);


### PR DESCRIPTION
implementa tests basicos, isso evita parcialmente o uso constante dos arquivos *.http para testar solicitações. Falta implementar testes para os controladores porem o mesmo estão reportando um erro que não consigo continuar o desenvolvimento para a construção dos proprios testes.