### PR TITLE
Fix qa reports gl 28_33

### DIFF
--- a/src/common/utils/isEmailFormatValid.ts
+++ b/src/common/utils/isEmailFormatValid.ts
@@ -1,0 +1,4 @@
+export function isEmailFormatValid(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}

--- a/src/contact/contact.controller.ts
+++ b/src/contact/contact.controller.ts
@@ -16,7 +16,6 @@ import {
 import {
   ApiBearerAuth,
   ApiOperation,
-  ApiParam,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -34,6 +33,7 @@ import { OkResponse } from '../swagger/decorators/ok.decorator';
 import { GetContactResponse } from './swagger/getContactResponse.swagger';
 import { NoContentResponse } from '../swagger/decorators/no-content.decorator';
 import { FindContactByNameDto } from './dto/find-contact-by-name.dto';
+import { BadRequestResponse } from '../swagger/decorators/bad-request.decorator';
 
 @UseGuards(AccessTokenGuard)
 @Controller('contact')
@@ -43,13 +43,14 @@ export class ContactController {
   constructor(private readonly contactService: ContactService) {}
 
   @Post()
-  @HttpCode(201)
+  @HttpCode(HttpStatus.CREATED)
   @UseGuards(AccessTokenGuard)
   @ApiOperation({
     summary: 'Create contact',
     description: 'Creates a new contact for the authenticated user',
   })
   @CreatedResponse('Contact created response successfully', 'contact created')
+  @BadRequestResponse()
   @UnauthorizedResponse()
   public async create(
     @Body() @AddRequestUserId() createContactDto: CreateContactDto,
@@ -97,6 +98,7 @@ export class ContactController {
   @NoContentResponse('Contact updated response successfully')
   @UnauthorizedResponse()
   @NotFoundResponse()
+  @BadRequestResponse()
   async update(
     @Param('id') id: string,
     @Body() @AddRequestUserId() updateContactDto: UpdateContactDto,
@@ -135,7 +137,6 @@ export class ContactController {
     const userId = request.user['sub'];
     return await this.contactService.remove(id, userId);
   }
-
 
   @Delete()
   @ApiOperation({ summary: 'Delete many contacts' })

--- a/src/contact/contact.service.ts
+++ b/src/contact/contact.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   Injectable,
   NotFoundException,
@@ -7,6 +8,7 @@ import { CreateContactDto } from './dto/create-contact.dto';
 import { UpdateContactDto } from './dto/update-contact.dto';
 import { PrismaService } from '../prisma/prisma.service';
 import { Channel, Contact } from '@prisma/client';
+import { isEmailFormatValid } from '../common/utils/isEmailFormatValid';
 
 @Injectable()
 export class ContactService {
@@ -24,11 +26,22 @@ export class ContactService {
 
     if (existingContact) {
       throw new ConflictException(
-        'Contact already exists for this user and identify',
+        'Já existe um contato que possui o mesmo nome e identificador',
       );
     }
 
     const channel = Channel[createData.channel.toUpperCase()];
+
+    if (channel === 'EMAIL') {
+      const emailValidation = isEmailFormatValid(createContactDto.identify);
+
+      if (!emailValidation) {
+        throw new BadRequestException(
+          'O formato de email informado é inválido',
+        );
+      }
+    }
+
     const contact = await this.prismaService.contact.create({
       data: {
         ...createData,

--- a/src/contact/dto/create-contact.dto.ts
+++ b/src/contact/dto/create-contact.dto.ts
@@ -24,6 +24,7 @@ export class CreateContactDto {
 
   @IsNotEmpty()
   @IsString()
+  @MinLength(4)
   @ApiProperty({ example: 'email@email.com' })
   identify: string;
 


### PR DESCRIPTION
Resolução dos seguintes bugs reportados pela equipe de QA:

GL-28: [PATCH/reminder{id}] Ao enviar uma requisição PATCH para editar um lembrete inserindo um contato inválido, o sistema responde com um 500 Internal Server Error.

GL-30: [POST/contact] é possivel criar contato com o nome excedendo a quantidade máx de caracteres (100)

GL-31: [POST/contact] o contato é criado mesmo com o campo email inválido

GL-32: [POST/contact] é possivel criar um contato mesmo que o campo email não respeite a quantidade minima de caracteres (4)

GL-33: [GET/contact{id}] Ao incluir um id inválido o resultado é 200 OK